### PR TITLE
Temporary set pydocstyle version to 3.*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pydocstyle==3.*
 flake8
 pytest
 pytest-cov


### PR DESCRIPTION
Get error while check my code by `flake8`.
Solution in issue:
https://github.com/PyCQA/pydocstyle/issues/375